### PR TITLE
fix: Update docs README.md to include correct command link

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -261,7 +261,7 @@ EXAMPLES
   $ fluence build
 ```
 
-_See code: [src/commands/build.ts](https://github.com/fluencelabs/cli/blob/v0.15.18/src/commands/build.ts)_
+_See code: [src/commands/build.ts](https://github.com/fluencelabs/cli/blob/main/src/commands/build.ts)_
 
 ## `fluence chain info`
 


### PR DESCRIPTION
1. command docs reference link fixed. 
2. Prioir took to an empty url