### PR TITLE
feat: add cc-remove and other provider and developer improvements [fixes DXJ-752]

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -44,6 +44,7 @@
 * [`fluence provider cc-activate`](#fluence-provider-cc-activate)
 * [`fluence provider cc-create`](#fluence-provider-cc-create)
 * [`fluence provider cc-info`](#fluence-provider-cc-info)
+* [`fluence provider cc-remove`](#fluence-provider-cc-remove)
 * [`fluence provider cc-withdraw-collateral`](#fluence-provider-cc-withdraw-collateral)
 * [`fluence provider cc-withdraw-rewards`](#fluence-provider-cc-withdraw-rewards)
 * [`fluence provider deal-exit [DEAL-IDS]`](#fluence-provider-deal-exit-deal-ids)
@@ -1183,8 +1184,7 @@ USAGE
 
 FLAGS
   --env=<dar | stage | local | custom>  Fluence Environment to use when running the command
-  --ids=<value>                         Comma separated capacity commitment IDs. Default: all noxes from
-                                        capacityCommitments property of the provider config
+  --ids=<value>                         Comma separated capacity commitment IDs
   --no-input                            Don't interactively ask for any input from the user
   --nox-names=<nox-1,nox-2>             Comma-separated names of noxes from provider.yaml. To use all of your noxes:
                                         --nox-names all
@@ -1235,10 +1235,11 @@ Get info about capacity commitments
 
 ```
 USAGE
-  $ fluence provider cc-info [--no-input] [--nox-names <value>] [--env <value>] [--priv-key <value>]
+  $ fluence provider cc-info [--no-input] [--env <value>] [--priv-key <value>] [--nox-names <value> | --ids <value>]
 
 FLAGS
   --env=<dar | stage | local | custom>  Fluence Environment to use when running the command
+  --ids=<value>                         Comma separated capacity commitment IDs
   --no-input                            Don't interactively ask for any input from the user
   --nox-names=<nox-1,nox-2>             Comma-separated names of noxes from provider.yaml. To use all of your noxes:
                                         --nox-names all
@@ -1255,6 +1256,34 @@ ALIASES
 ```
 
 _See code: [src/commands/provider/cc-info.ts](https://github.com/fluencelabs/cli/blob/v0.15.19/src/commands/provider/cc-info.ts)_
+
+## `fluence provider cc-remove`
+
+Remove Capacity commitment. You can remove it only BEFORE you activated it by depositing collateral
+
+```
+USAGE
+  $ fluence provider cc-remove [--no-input] [--env <value>] [--priv-key <value>] [--nox-names <value> | --ids <value>]
+
+FLAGS
+  --env=<dar | stage | local | custom>  Fluence Environment to use when running the command
+  --ids=<value>                         Comma separated capacity commitment IDs
+  --no-input                            Don't interactively ask for any input from the user
+  --nox-names=<nox-1,nox-2>             Comma-separated names of noxes from provider.yaml. To use all of your noxes:
+                                        --nox-names all
+  --priv-key=<private-key>              !WARNING! for debug purposes only. Passing private keys through flags is
+                                        unsecure. On local network
+                                        0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 key will be
+                                        used by default
+
+DESCRIPTION
+  Remove Capacity commitment. You can remove it only BEFORE you activated it by depositing collateral
+
+ALIASES
+  $ fluence provider cr
+```
+
+_See code: [src/commands/provider/cc-remove.ts](https://github.com/fluencelabs/cli/blob/v0.15.19/src/commands/provider/cc-remove.ts)_
 
 ## `fluence provider cc-withdraw-collateral`
 

--- a/docs/configs/provider.md
+++ b/docs/configs/provider.md
@@ -183,6 +183,7 @@ Configuration to pass to the nox compute peer. Config.toml files are generated f
 | Property                 | Type                      | Required | Description                                                                                                       |
 |--------------------------|---------------------------|----------|-------------------------------------------------------------------------------------------------------------------|
 | `aquavmPoolSize`         | integer                   | No       | Number of aquavm instances to run. Default: 2                                                                     |
+| `bootstrapNodes`         | string[]                  | No       | List of bootstrap nodes. Default: all addresses for the selected env                                              |
 | `ccp`                    | [object](#ccp)            | No       | For advanced users. CCP config                                                                                    |
 | `chain`                  | [object](#chain)          | No       | Chain config                                                                                                      |
 | `cpusRange`              | string                    | No       | Range of CPU cores to use. Default: 1-32                                                                          |
@@ -331,6 +332,7 @@ Configuration to pass to the nox compute peer. Config.toml files are generated f
 | Property                 | Type                      | Required | Description                                                                                                       |
 |--------------------------|---------------------------|----------|-------------------------------------------------------------------------------------------------------------------|
 | `aquavmPoolSize`         | integer                   | No       | Number of aquavm instances to run. Default: 2                                                                     |
+| `bootstrapNodes`         | string[]                  | No       | List of bootstrap nodes. Default: all addresses for the selected env                                              |
 | `ccp`                    | [object](#ccp)            | No       | For advanced users. CCP config                                                                                    |
 | `chain`                  | [object](#chain)          | No       | Chain config                                                                                                      |
 | `cpusRange`              | string                    | No       | Range of CPU cores to use. Default: 1-32                                                                          |

--- a/src/commands/default/env.ts
+++ b/src/commands/default/env.ts
@@ -24,10 +24,8 @@ import { initNewWorkersConfigReadonly } from "../../lib/configs/project/workers.
 import { ENV_ARG } from "../../lib/const.js";
 import { ensureAquaFileWithWorkerInfo } from "../../lib/deployWorkers.js";
 import { initCli } from "../../lib/lifeCycle.js";
-import {
-  ensureCustomAddrsAndPeerIds,
-  updateRelaysJSON,
-} from "../../lib/multiaddres.js";
+import { updateRelaysJSON } from "../../lib/multiaddres.js";
+import { ensureCustomAddrsAndPeerIds } from "../../lib/multiaddresWithoutLocal.js";
 import { ensureValidFluenceEnv } from "../../lib/resolveFluenceEnv.js";
 
 export default class Env extends BaseCommand<typeof Env> {

--- a/src/commands/delegator/collateral-add.ts
+++ b/src/commands/delegator/collateral-add.ts
@@ -19,9 +19,7 @@ import { Args } from "@oclif/core";
 import { BaseCommand, baseFlags } from "../../baseCommand.js";
 import { depositCollateral } from "../../lib/chain/depositCollateral.js";
 import { CHAIN_FLAGS, FLT_SYMBOL } from "../../lib/const.js";
-import { commaSepStrToArr } from "../../lib/helpers/utils.js";
 import { initCli } from "../../lib/lifeCycle.js";
-import { input } from "../../lib/prompt.js";
 
 export default class AddCollateral extends BaseCommand<typeof AddCollateral> {
   static override aliases = ["delegator:ca"];
@@ -38,16 +36,6 @@ export default class AddCollateral extends BaseCommand<typeof AddCollateral> {
 
   async run(): Promise<void> {
     const { args } = await initCli(this, await this.parse(AddCollateral));
-
-    await depositCollateral(
-      commaSepStrToArr(
-        args.IDS ??
-          (await input({
-            message: "Enter comma-separated capacity commitment IDs",
-          })),
-      ).map((commitmentId) => {
-        return { commitmentId };
-      }),
-    );
+    await depositCollateral({ ids: args.IDS });
   }
 }

--- a/src/commands/local/up.ts
+++ b/src/commands/local/up.ts
@@ -21,7 +21,7 @@ import { Flags } from "@oclif/core";
 
 import { BaseCommand, baseFlags } from "../../baseCommand.js";
 import { createCommitments } from "../../lib/chain/commitment.js";
-import { depositCollateralByNoxNames } from "../../lib/chain/depositCollateral.js";
+import { depositCollateral } from "../../lib/chain/depositCollateral.js";
 import { distributeToNox } from "../../lib/chain/distributeToNox.js";
 import { createOffers } from "../../lib/chain/offer.js";
 import { registerProvider } from "../../lib/chain/providerInfo.js";
@@ -174,6 +174,6 @@ export default class Up extends BaseCommand<typeof Up> {
     });
 
     await createCommitments({ ...flags, ...allNoxNames, env });
-    await depositCollateralByNoxNames(allNoxNames);
+    await depositCollateral(allNoxNames);
   }
 }

--- a/src/commands/provider/cc-remove.ts
+++ b/src/commands/provider/cc-remove.ts
@@ -15,13 +15,16 @@
  */
 
 import { BaseCommand, baseFlags } from "../../baseCommand.js";
-import { depositCollateral } from "../../lib/chain/depositCollateral.js";
-import { CC_FLAGS, CHAIN_FLAGS, FLT_SYMBOL } from "../../lib/const.js";
+import { removeCommitments } from "../../lib/chain/commitment.js";
+import { CC_FLAGS, CHAIN_FLAGS } from "../../lib/const.js";
 import { initCli } from "../../lib/lifeCycle.js";
 
-export default class AddCollateral extends BaseCommand<typeof AddCollateral> {
-  static override description = `Add ${FLT_SYMBOL} collateral to capacity commitment to activate it`;
-  static override aliases = ["provider:ca"];
+export default class RemoveCommitment extends BaseCommand<
+  typeof RemoveCommitment
+> {
+  static override aliases = ["provider:cr"];
+  static override description =
+    "Remove Capacity commitment. You can remove it only BEFORE you activated it by depositing collateral";
   static override flags = {
     ...baseFlags,
     ...CHAIN_FLAGS,
@@ -29,7 +32,7 @@ export default class AddCollateral extends BaseCommand<typeof AddCollateral> {
   };
 
   async run(): Promise<void> {
-    const { flags } = await initCli(this, await this.parse(AddCollateral));
-    await depositCollateral(flags);
+    const { flags } = await initCli(this, await this.parse(RemoveCommitment));
+    await removeCommitments(flags);
   }
 }

--- a/src/lib/chain/commitment.ts
+++ b/src/lib/chain/commitment.ts
@@ -16,20 +16,127 @@
 
 import { color } from "@oclif/color";
 import parse from "parse-duration";
+import { yamlDiffPatch } from "yaml-diff-patch";
 
 import { commandObj } from "../commandObj.js";
-import { resolveComputePeersByNames } from "../configs/project/provider.js";
+import {
+  resolveComputePeersByNames,
+  type ResolvedComputePeer,
+} from "../configs/project/provider.js";
 import { CLI_NAME, NOX_NAMES_FLAG_NAME } from "../const.js";
 import { dbg } from "../dbg.js";
+import { getDealClient, getEventValues, signBatch } from "../dealClient.js";
 import {
-  getDealClient,
-  getEventValues,
-  signBatch,
-  type CallsToBatch,
-} from "../dealClient.js";
-import { splitErrorsAndResults, stringifyUnknown } from "../helpers/utils.js";
+  splitErrorsAndResults,
+  stringifyUnknown,
+  commaSepStrToArr,
+} from "../helpers/utils.js";
 
-import { peerIdToUint8Array } from "./conversions.js";
+import {
+  peerIdHexStringToBase58String,
+  peerIdToUint8Array,
+} from "./conversions.js";
+
+export type ComputePeersWithCC = Awaited<
+  ReturnType<typeof getComputePeersWithCC>
+>;
+
+export async function getComputePeersWithCC(
+  computePeers: ResolvedComputePeer[],
+) {
+  const { dealClient } = await getDealClient();
+  const market = await dealClient.getMarket();
+  const capacity = await dealClient.getCapacity();
+
+  const commitmentCreatedEvents = Object.fromEntries(
+    await Promise.all(
+      (await capacity.queryFilter(capacity.filters.CommitmentCreated)).map(
+        async (event) => {
+          return [
+            await peerIdHexStringToBase58String(event.args.peerId),
+            event,
+          ] as const;
+        },
+      ),
+    ),
+  );
+
+  const computePeersWithChainInfo = (
+    await Promise.all(
+      computePeers.map(async (computePeer) => {
+        const peerIdUint8Array = await peerIdToUint8Array(computePeer.peerId);
+
+        return {
+          providerConfigComputePeer: computePeer,
+          commitmentCreatedEvent: commitmentCreatedEvents[computePeer.peerId],
+          marketGetComputePeerRes: await (async () => {
+            try {
+              return await market.getComputePeer(peerIdUint8Array);
+            } catch {
+              return undefined;
+            }
+          })(),
+        };
+      }),
+    )
+  ).map((c) => {
+    const commitmentId =
+      c.commitmentCreatedEvent?.args.commitmentId ??
+      c.marketGetComputePeerRes?.commitmentId;
+
+    if (commitmentId === undefined) {
+      return c;
+    }
+
+    return { ...c, commitmentId };
+  });
+
+  const [computePeersWithoutCCId, computePeersWithCCId] = splitErrorsAndResults(
+    computePeersWithChainInfo,
+    (computePeerWithChainInfo) => {
+      if ("commitmentId" in computePeerWithChainInfo) {
+        return {
+          result: computePeerWithChainInfo,
+        };
+      }
+
+      return {
+        error: computePeerWithChainInfo,
+      };
+    },
+  );
+
+  if (computePeersWithoutCCId.length > 0) {
+    commandObj.warn(
+      `Some of the commitments are not found on chain for:\n${computePeersWithoutCCId
+        .map(({ providerConfigComputePeer: { name, peerId } }) => {
+          return `Nox: ${name}, PeerId: ${peerId}`;
+        })
+        .join(
+          "\n",
+        )}\n\nYou can create commitments using '${CLI_NAME} provider cc-create' command.`,
+    );
+  }
+
+  return computePeersWithCCId;
+}
+
+export type CCFlags = {
+  [NOX_NAMES_FLAG_NAME]?: string | undefined;
+  ids?: string | undefined;
+};
+
+export async function getCommitments(
+  flags: CCFlags,
+): Promise<{ commitmentId: string }[] | ComputePeersWithCC> {
+  if (flags.ids !== undefined) {
+    return commaSepStrToArr(flags.ids).map((commitmentId) => {
+      return { commitmentId };
+    });
+  }
+
+  return getComputePeersWithCC(await resolveComputePeersByNames(flags));
+}
 
 export async function createCommitments(flags: {
   env: string | undefined;
@@ -45,64 +152,60 @@ export async function createCommitments(flags: {
 
   const [createCommitmentsTxsErrors, createCommitmentsTxs] =
     splitErrorsAndResults(
-      await Promise.allSettled(
-        computePeers.map(
-          async ({
-            peerId,
-            capacityCommitment,
-            name,
-          }): Promise<
-            CallsToBatch<Parameters<typeof capacity.createCommitment>>[number]
-          > => {
-            const peerIdUint8Arr = await peerIdToUint8Array(peerId);
+      await Promise.all(
+        computePeers.map(async ({ peerId, capacityCommitment, name }) => {
+          let peerIdUint8Arr;
 
-            const durationInSec = BigInt(
-              (parse(capacityCommitment.duration) ?? 0) / 1000,
-            );
+          try {
+            peerIdUint8Arr = await peerIdToUint8Array(peerId);
+          } catch (e) {
+            return {
+              error: `Invalid peerId: ${peerId}. Error: ${stringifyUnknown(e)}`,
+            };
+          }
 
-            dbg(
-              `initTimestamp: ${await core.initTimestamp()} Epoch duration: ${epochDuration.toString()}. Current epoch: ${await core.currentEpoch()}`,
-            );
+          const durationInSec = BigInt(
+            (parse(capacityCommitment.duration) ?? 0) / 1000,
+          );
 
-            dbg(`Duration in seconds: ${durationInSec.toString()}`);
-            const durationEpoch = durationInSec / epochDuration;
-            dbg(`Duration in epochs: ${durationEpoch.toString()}`);
-            const ccDelegator = capacityCommitment.delegator;
+          dbg(
+            `initTimestamp: ${await core.initTimestamp()} Epoch duration: ${epochDuration.toString()}. Current epoch: ${await core.currentEpoch()}`,
+          );
 
-            const minDuration = await capacity.minDuration();
+          dbg(`Duration in seconds: ${durationInSec.toString()}`);
+          const durationEpoch = durationInSec / epochDuration;
+          dbg(`Duration in epochs: ${durationEpoch.toString()}`);
+          const ccDelegator = capacityCommitment.delegator;
 
-            if (durationEpoch < minDuration) {
-              return commandObj.error(
-                `Duration for ${color.yellow(
-                  name,
-                )} must be at least ${color.yellow(
-                  minDuration * epochDuration,
-                )} seconds. Got: ${color.yellow(durationInSec)} seconds`,
-              );
-            }
+          const minDuration = await capacity.minDuration();
 
-            const ccRewardDelegationRate = Math.floor(
-              (capacityCommitment.rewardDelegationRate / 100) *
-                Number(precision),
-            );
+          if (durationEpoch < minDuration) {
+            return {
+              error: `Duration for ${color.yellow(
+                name,
+              )} must be at least ${color.yellow(
+                minDuration * epochDuration,
+              )} seconds. Got: ${color.yellow(durationInSec)} seconds`,
+            };
+          }
 
-            return [
+          const ccRewardDelegationRate = Math.floor(
+            (capacityCommitment.rewardDelegationRate / 100) * Number(precision),
+          );
+
+          return {
+            result: [
               capacity.createCommitment,
               peerIdUint8Arr,
               durationEpoch,
               ccDelegator ?? ethers.ZeroAddress,
               ccRewardDelegationRate,
-            ];
-          },
-        ),
+            ] as const,
+          };
+        }),
       ),
-      (res) => {
-        if (res.status === "fulfilled") {
-          return { result: res.value };
-        }
-
-        const error: unknown = res.reason;
-        return { error: stringifyUnknown(error) };
+      (val) => {
+        return val;
       },
     );
 
@@ -117,7 +220,11 @@ export async function createCommitments(flags: {
   let createCommitmentsTxReceipts;
 
   try {
-    createCommitmentsTxReceipts = await signBatch(createCommitmentsTxs);
+    createCommitmentsTxReceipts = await signBatch(
+      createCommitmentsTxs.map((tx) => {
+        return [...tx];
+      }),
+    );
   } catch (e) {
     const errorString = stringifyUnknown(e);
 
@@ -175,4 +282,106 @@ export async function createCommitments(flags: {
   );
 
   return stringCommitmentIds;
+}
+
+export async function removeCommitments(flags: CCFlags) {
+  const commitments = await getCommitments(flags);
+  const { dealClient } = await getDealClient();
+  const capacity = await dealClient.getCapacity();
+
+  const [commitmentInfoErrors, commitmentInfo] = splitErrorsAndResults(
+    await Promise.all(
+      commitments.map(async (commitment) => {
+        try {
+          return {
+            result: {
+              commitment,
+              info: await capacity.getCommitment(commitment.commitmentId),
+            },
+          };
+        } catch (error) {
+          return { error: { commitment, error } };
+        }
+      }),
+    ),
+    (res) => {
+      return res;
+    },
+  );
+
+  if (commitmentInfoErrors.length > 0) {
+    commandObj.error(
+      `Wasn't able to get commitments from chain:\n${commitmentInfoErrors
+        .map(({ commitment, error }) => {
+          return `${stringifyBasicCommitmentInfo(commitment)}\n\n${color.red(
+            stringifyUnknown(error),
+          )}`;
+        })
+        .join("\n\n")}`,
+    );
+  }
+
+  const commitmentsWithInvalidStatus = commitmentInfo.filter(({ info }) => {
+    return ccStatusToString(info.status) !== "WaitDelegation";
+  });
+
+  if (commitmentsWithInvalidStatus.length > 0) {
+    commandObj.error(
+      `You can remove commitments only if they have WaitDelegation status. Got:\n\n${commitmentsWithInvalidStatus
+        .map(({ commitment, info }) => {
+          return `${stringifyBasicCommitmentInfo(
+            commitment,
+          )}Status: ${ccStatusToString(info.status)}`;
+        })
+        .join("\n\n")}`,
+    );
+  }
+
+  await signBatch(
+    commitments.map(({ commitmentId }) => {
+      return [capacity.removeCommitment, commitmentId];
+    }),
+  );
+
+  commandObj.logToStderr(
+    `Removed commitments:\n\n${commitments
+      .map((commitment) => {
+        return stringifyBasicCommitmentInfo(commitment);
+      })
+      .join("\n")}`,
+  );
+}
+
+function stringifyBasicCommitmentInfo(
+  commitment: Awaited<ReturnType<typeof getCommitments>>[number],
+) {
+  if ("providerConfigComputePeer" in commitment) {
+    return `${color.yellow(
+      `Nox: ${commitment.providerConfigComputePeer.name}`,
+    )}\n${yamlDiffPatch(
+      "",
+      {},
+      {
+        PeerId: commitment.providerConfigComputePeer.peerId,
+        CommitmentId: commitment.commitmentId,
+      },
+    )}`;
+  }
+
+  return color.yellow(`CommitmentId: ${commitment.commitmentId}`);
+}
+
+export function ccStatusToString(status: bigint | undefined) {
+  return (
+    (
+      [
+        "Active",
+        "WaitDelegation",
+        "WaitStart",
+        "Inactive",
+        "Failed",
+        "Removed",
+      ] as const
+    )[Number(status)] ?? "Unknown"
+  );
 }

--- a/src/lib/chain/offer.ts
+++ b/src/lib/chain/offer.ts
@@ -69,8 +69,8 @@ export type OffersArgs = {
 };
 
 export async function createOffers(flags: OffersArgs) {
-  await assertProviderIsRegistered();
   const offers = await resolveOffersFromProviderConfig(flags);
+  await assertProviderIsRegistered();
   const { dealClient } = await getDealClient();
   const market = await dealClient.getMarket();
   const usdc = await dealClient.getUSDC();
@@ -290,8 +290,8 @@ async function resolveOfferInfo({
 }
 
 export async function updateOffers(flags: OffersArgs) {
-  await assertProviderIsRegistered();
   const offers = await resolveOffersFromProviderConfig(flags);
+  await assertProviderIsRegistered();
   const { dealClient } = await getDealClient();
   const market = await dealClient.getMarket();
 

--- a/src/lib/configs/project/provider.ts
+++ b/src/lib/configs/project/provider.ts
@@ -381,54 +381,26 @@ type NoxConfigYAMLV1 = Omit<NoxConfigYAMLV0, "chainConfig"> & {
     | "marketContractAddress"
     | "walletKey"
   > & {
-    // new. goes to chain_listener_config
     wsEndpoint?: string;
-    // new. goes to decider
     dealSyncStartBlock?: string;
-    // renamed
     marketContract?: string;
     ccContract?: string;
     coreContract?: string;
     walletPrivateKey?: string;
   };
   ccp?: {
-    // # NOX TOML: chain_listener_config.ccp_endpoint
-    // http://{ccp.rpcEndpoint.host}:{ccp.rpcEndpoint.port}
     ccpEndpoint?: string;
-    // # NOX TOML: chain_listener_config.proof_poll_period
-    // # Optional "60 seconds"
     proofPollPeriod?: string;
   };
   ipfs?: {
-    // # TOML: system_services.aqua_ipfs.external_api_multiaddr
-    // # Required
     externalApiMultiaddr?: string;
-    // # TOML: system_services.aqua_ipfs.local_api_multiaddr
-    // # Optional
     localApiMultiaddr?: string;
     ipfsBinaryPath?: string;
   };
-  // # these would
-  // cpusRange = "1-32" # It's actually possible to do complex things like "1,3-6,7-20,32", Nox will parse
-  // systemCpuCount = 1 # That's how much cores to allocate for the Nox itself. 0 is forbidden, cuz don't be greedy!
   cpusRange?: string;
   systemCpuCount?: number;
-  // # this would go to listen_config.listen_ip in Nox's Config.toml
-  // listenIp = "1.2.3.4"
-  // # would go to global external_multiaddresses in TOML
-  // externalMultiaddresses = ["/dns4/who.is.it.org/tcp/9999/ws", "/ip4/10.9.8.7/tcp/3210"]
   listenIp?: string;
   externalMultiaddresses?: Array<string>;
-  // # prometheus metrics will be available at {listen_id}:{httpPort}/metrics
-  // metrics:
-  //   # TOML: metrics_config.metrics_enabled
-  //   enabled = true
-  //   # TOML: metrics_config.metrics_timer_resolution
-  //   timer_resolution = "1 minute"
-  //   # TOML: tokio_metrics_enabled
-  //   tokio_metrics_enabled = true
-  //   # TOML: tokio_metrics_poll_histogram_enabled
-  //   tokio_detailed_metrics_enabled = true # could be expensive performance-wise
   metrics?: {
     enabled?: boolean;
     timerResolution?: string;
@@ -1673,16 +1645,7 @@ function noxConfigYAMLToConfigToml(
             proofPollPeriod: ccp?.proofPollPeriod,
           },
         }),
-    tokioMetricsEnabled: metrics?.tokioMetricsEnabled,
-    tokioDetailedMetricsEnabled: metrics?.tokioDetailedMetricsEnabled,
-    ...(metrics?.enabled !== undefined || metrics?.timerResolution !== undefined
-      ? {
-          metricsConfig: {
-            metricsEnabled: metrics.enabled,
-            metricsTimerResolution: metrics.timerResolution,
-          },
-        }
-      : {}),
+    ...metrics,
   }) as JsonMap;
 }
 

--- a/src/lib/configs/project/provider.ts
+++ b/src/lib/configs/project/provider.ts
@@ -1645,7 +1645,10 @@ function noxConfigYAMLToConfigToml(
             proofPollPeriod: ccp?.proofPollPeriod,
           },
         }),
-    ...metrics,
+    tokioMetricsEnabled: metrics?.tokioMetricsEnabled,
+    tokioDetailedMetricsEnabled: metrics?.tokioDetailedMetricsEnabled,
+    metricsEnabled: metrics?.enabled,
+    metricsTimerResolution: metrics?.timerResolution,
   }) as JsonMap;
 }
 

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -509,6 +509,17 @@ export const FLUENCE_CLIENT_FLAGS = {
   ...ENV_FLAG,
 } as const;
 
+export const CC_FLAGS = {
+  [NOX_NAMES_FLAG_NAME]: Flags.string({
+    ...NOX_NAMES_FLAG_CONFIG,
+    exclusive: ["ids"],
+  }),
+  ids: Flags.string({
+    description: "Comma separated capacity commitment IDs",
+    exclusive: [NOX_NAMES_FLAG_NAME],
+  }),
+};
+
 export type FluenceClientFlags = FromFlagsDef<typeof FLUENCE_CLIENT_FLAGS>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/dealClient.ts
+++ b/src/lib/dealClient.ts
@@ -189,7 +189,7 @@ async function getWalletConnectProvider() {
     url.searchParams.set(KEY_QUERY_PARAM_NAME, key);
 
     commandObj.logToStderr(
-      `To approve transactions to your wallet using metamask, open the following url:\n\n${url.toString()}\n\nor go to ${CLI_CONNECTOR_URL} and enter the following connection string there:\n\n${uri}\n`,
+      `To continue, please connect your wallet using metamask by opening the following url:\n\n${url.toString()}\n\nor go to ${CLI_CONNECTOR_URL} and enter the following connection string there:\n\n${uri}\n`,
     );
   });
 

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -166,7 +166,9 @@ export async function deployImpl(this: Deploy, cl: typeof Deploy) {
         ? !(await confirm({
             message: `You previously deployed ${color.yellow(
               workerName,
-            )}, but this deal is already ended. Do you want to create a new deal and overwrite the old one? (at ${workersConfig.$getPath()})\nPlease keep this deal id ${previouslyDeployedDeal.dealIdOriginal} to withdraw the money from it after state overwrite`,
+            )}, but this deal is already ended. Do you want to create a new deal and overwrite the old one? (at ${workersConfig.$getPath()})\nPlease keep this deal id ${
+              previouslyDeployedDeal.dealIdOriginal
+            } to withdraw the money from it after state overwrite`,
             default: true,
           }))
         : true;

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -166,7 +166,7 @@ export async function deployImpl(this: Deploy, cl: typeof Deploy) {
         ? !(await confirm({
             message: `You previously deployed ${color.yellow(
               workerName,
-            )}, but this deal is already ended. Do you want to create a new deal and overwrite the old one? (at ${workersConfig.$getPath()})\nPlease keep this deal id ${deal.id} to withdraw the money from it after state overwrite`,
+            )}, but this deal is already ended. Do you want to create a new deal and overwrite the old one? (at ${workersConfig.$getPath()})\nPlease keep this deal id ${previouslyDeployedDeal.dealIdOriginal} to withdraw the money from it after state overwrite`,
             default: true,
           }))
         : true;

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -166,7 +166,7 @@ export async function deployImpl(this: Deploy, cl: typeof Deploy) {
         ? !(await confirm({
             message: `You previously deployed ${color.yellow(
               workerName,
-            )}, but this deal is already ended. Do you want to create a new deal and overwrite an old one? (at ${workersConfig.$getPath()})\nYou will not be able to withdraw money from the old deal after that`,
+            )}, but this deal is already ended. Do you want to create a new deal and overwrite the old one? (at ${workersConfig.$getPath()})\nPlease keep this deal id ${deal.id} to withdraw the money from it after state overwrite`,
             default: true,
           }))
         : true;

--- a/src/lib/multiaddres.ts
+++ b/src/lib/multiaddres.ts
@@ -18,13 +18,7 @@ import { writeFile, mkdir } from "fs/promises";
 import assert from "node:assert";
 import { isAbsolute, join, resolve } from "node:path";
 
-import {
-  stage,
-  testNet,
-  type Node as AddrAndPeerId,
-} from "@fluencelabs/fluence-network-environment";
-// TODO: replace with dynamic import
-import { multiaddr } from "@multiformats/multiaddr";
+import { type Node as AddrAndPeerId } from "@fluencelabs/fluence-network-environment";
 import { color } from "@oclif/color";
 import sample from "lodash-es/sample.js";
 
@@ -32,29 +26,14 @@ import { commandObj } from "./commandObj.js";
 import { envConfig } from "./configs/globalConfigs.js";
 import { initFluenceConfig } from "./configs/project/fluence.js";
 import { ensureComputerPeerConfigs } from "./configs/project/provider.js";
+import { FLUENCE_ENVS, type FluenceEnv } from "./const.js";
+import { jsonStringify, splitErrorsAndResults } from "./helpers/utils.js";
 import {
-  FLUENCE_ENVS,
-  type FluenceEnv,
-  type PublicFluenceEnv,
-  CHAIN_ENV,
-} from "./const.js";
-import {
-  commaSepStrToArr,
-  jsonStringify,
-  splitErrorsAndResults,
-} from "./helpers/utils.js";
+  getPeerId,
+  resolveAddrsAndPeerIdsWithoutLocal,
+} from "./multiaddresWithoutLocal.js";
 import { projectRootDir } from "./paths.js";
-import { input, list } from "./prompt.js";
 import { ensureFluenceEnv } from "./resolveFluenceEnv.js";
-
-export function addrsToNodes(multiaddrs: string[]): AddrAndPeerId[] {
-  return multiaddrs.map((multiaddr) => {
-    return {
-      peerId: getPeerId(multiaddr),
-      multiaddr,
-    };
-  });
-}
 
 async function ensureLocalAddrsAndPeerIds() {
   return (await ensureComputerPeerConfigs()).map(
@@ -67,86 +46,14 @@ async function ensureLocalAddrsAndPeerIds() {
   );
 }
 
-const ADDR_MAP: Record<PublicFluenceEnv, Array<AddrAndPeerId>> = {
-  // kras: krasnodar,
-  dar: testNet,
-  stage,
-};
-
-export async function ensureCustomAddrsAndPeerIds() {
-  const fluenceConfig = await initFluenceConfig();
-
-  if (fluenceConfig === null) {
-    commandObj.error(
-      `You must init fluence project if you want to use ${color.yellow(
-        "custom",
-      )} fluence env`,
-    );
-  }
-
-  if (fluenceConfig.customFluenceEnv?.relays !== undefined) {
-    let res;
-
-    try {
-      res = addrsToNodes(fluenceConfig.customFluenceEnv.relays);
-    } catch (e) {
-      commandObj.error(
-        `${fluenceConfig.$getPath()} at ${color.yellow(
-          "customFluenceEnv.relays",
-        )}: ${e instanceof Error ? e.message : String(e)}`,
-      );
-    }
-
-    return res;
-  }
-
-  const contractsEnv = await list({
-    message: "Select contracts environment for your custom network",
-    options: [...CHAIN_ENV],
-    oneChoiceMessage: (): never => {
-      throw new Error("Unreachable: only one contracts env");
-    },
-    onNoChoices: (): never => {
-      throw new Error("Unreachable: no contracts envs");
-    },
-  });
-
-  const fluenceEnvOrCustomRelays = commaSepStrToArr(
-    await input({
-      message: "Enter comma-separated list of relays",
-      validate: (input: string) => {
-        const relays = commaSepStrToArr(input);
-
-        if (relays.length === 0) {
-          return "You must specify at least one relay";
-        }
-
-        return true;
-      },
-    }),
-  );
-
-  fluenceConfig.customFluenceEnv = {
-    contractsEnv,
-    relays: fluenceEnvOrCustomRelays,
-  };
-
-  await fluenceConfig.$commit();
-  return addrsToNodes(fluenceEnvOrCustomRelays);
-}
-
 export async function resolveAddrsAndPeerIds(): Promise<AddrAndPeerId[]> {
   const fluenceEnv = await ensureFluenceEnv();
-
-  if (fluenceEnv === "custom") {
-    return ensureCustomAddrsAndPeerIds();
-  }
 
   if (fluenceEnv === "local") {
     return ensureLocalAddrsAndPeerIds();
   }
 
-  return ADDR_MAP[fluenceEnv];
+  return resolveAddrsAndPeerIdsWithoutLocal(fluenceEnv);
 }
 
 export async function resolveRelays(): Promise<Array<string>> {
@@ -271,18 +178,6 @@ export async function resolvePeerId(peerIdOrNamedNode: string) {
 
 export async function getRandomPeerId(): Promise<string> {
   return getPeerId(await getRandomRelayAddr());
-}
-
-export function getPeerId(addr: string): string {
-  const id = multiaddr(addr).getPeerId();
-
-  if (id === null) {
-    return commandObj.error(
-      `Can't extract peer id from multiaddr ${color.yellow(addr)}`,
-    );
-  }
-
-  return id;
 }
 
 export async function updateRelaysJSON() {

--- a/src/lib/multiaddresWithoutLocal.ts
+++ b/src/lib/multiaddresWithoutLocal.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2023 Fluence Labs Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type Node as AddrAndPeerId,
+  stage,
+  testNet,
+} from "@fluencelabs/fluence-network-environment";
+import { multiaddr } from "@multiformats/multiaddr";
+import { color } from "@oclif/color";
+
+import { commandObj } from "./commandObj.js";
+import { initFluenceConfig } from "./configs/project/fluence.js";
+import { CHAIN_ENV, type PublicFluenceEnv, type FluenceEnv } from "./const.js";
+import { commaSepStrToArr } from "./helpers/utils.js";
+import { input, list } from "./prompt.js";
+
+export function getPeerId(addr: string): string {
+  const id = multiaddr(addr).getPeerId();
+
+  if (id === null) {
+    return commandObj.error(
+      `Can't extract peer id from multiaddr ${color.yellow(addr)}`,
+    );
+  }
+
+  return id;
+}
+
+function addrsToNodes(multiaddrs: string[]): AddrAndPeerId[] {
+  return multiaddrs.map((multiaddr) => {
+    return {
+      peerId: getPeerId(multiaddr),
+      multiaddr,
+    };
+  });
+}
+
+export async function ensureCustomAddrsAndPeerIds() {
+  const fluenceConfig = await initFluenceConfig();
+
+  if (fluenceConfig === null) {
+    commandObj.error(
+      `You must init fluence project if you want to use ${color.yellow(
+        "custom",
+      )} fluence env`,
+    );
+  }
+
+  if (fluenceConfig.customFluenceEnv?.relays !== undefined) {
+    let res;
+
+    try {
+      res = addrsToNodes(fluenceConfig.customFluenceEnv.relays);
+    } catch (e) {
+      commandObj.error(
+        `${fluenceConfig.$getPath()} at ${color.yellow(
+          "customFluenceEnv.relays",
+        )}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+
+    return res;
+  }
+
+  const contractsEnv = await list({
+    message: "Select contracts environment for your custom network",
+    options: [...CHAIN_ENV],
+    oneChoiceMessage: (): never => {
+      throw new Error("Unreachable: only one contracts env");
+    },
+    onNoChoices: (): never => {
+      throw new Error("Unreachable: no contracts envs");
+    },
+  });
+
+  const fluenceEnvOrCustomRelays = commaSepStrToArr(
+    await input({
+      message: "Enter comma-separated list of relays",
+      validate: (input: string) => {
+        const relays = commaSepStrToArr(input);
+
+        if (relays.length === 0) {
+          return "You must specify at least one relay";
+        }
+
+        return true;
+      },
+    }),
+  );
+
+  fluenceConfig.customFluenceEnv = {
+    contractsEnv,
+    relays: fluenceEnvOrCustomRelays,
+  };
+
+  await fluenceConfig.$commit();
+  return addrsToNodes(fluenceEnvOrCustomRelays);
+}
+
+const ADDR_MAP: Record<PublicFluenceEnv, Array<AddrAndPeerId>> = {
+  // kras: krasnodar,
+  dar: testNet,
+  stage,
+};
+
+export async function resolveAddrsAndPeerIdsWithoutLocal(
+  env: Exclude<FluenceEnv, "local">,
+): Promise<AddrAndPeerId[]> {
+  if (env === "custom") {
+    return ensureCustomAddrsAndPeerIds();
+  }
+
+  return ADDR_MAP[env];
+}
+
+export async function resolveRelaysWithoutLocal(
+  env: Exclude<FluenceEnv, "local">,
+): Promise<Array<string>> {
+  return (await resolveAddrsAndPeerIdsWithoutLocal(env)).map((node) => {
+    return node.multiaddr;
+  });
+}

--- a/src/lib/multiaddresWithoutLocal.ts
+++ b/src/lib/multiaddresWithoutLocal.ts
@@ -40,7 +40,7 @@ export function getPeerId(addr: string): string {
   return id;
 }
 
-function addrsToNodes(multiaddrs: string[]): AddrAndPeerId[] {
+export function addrsToNodes(multiaddrs: string[]): AddrAndPeerId[] {
   return multiaddrs.map((multiaddr) => {
     return {
       peerId: getPeerId(multiaddr),

--- a/test/helpers/sharedSteps.ts
+++ b/test/helpers/sharedSteps.ts
@@ -45,7 +45,7 @@ import {
   setTryTimeout,
   stringifyUnknown,
 } from "../../src/lib/helpers/utils.js";
-import { addrsToNodes } from "../../src/lib/multiaddres.js";
+import { addrsToNodes } from "../../src/lib/multiaddresWithoutLocal.js";
 import { getAquaMainPath } from "../../src/lib/paths.js";
 import { validateDeployedServicesAnswerSchema } from "../validators/deployedServicesAnswerValidator.js";
 import { validateSpellLogs } from "../validators/spellLogsValidator.js";


### PR DESCRIPTION
- enabled metrics for noxes by default like this
```
tokio_metrics_enabled = true
metrics_enabled = true
metrics_timer_resolution = "1 minute"
```
- added `bootstrap_nodes` for non-local environments
- assert provider is registered after offer is selected so you see a prompt to connect your wallet only after that
- improved message for the request to connect your wallet
- allow using both IDs and names for all CC related commands. Getting cc ids by name from provider.yaml should hopefully work now on dar. Previously you had to use ids to add collateral
- added `cc-remove` command
- if deal status is Ended - ask user if he wants to replace previously deployed deal with a new one