### PR TITLE
fix(offer-create): offer-update suggestion typo

### DIFF
--- a/src/lib/chain/offer.ts
+++ b/src/lib/chain/offer.ts
@@ -90,7 +90,7 @@ export async function createOffers(flags: OffersArgs) {
         })
         .join(
           ", ",
-        )}. You can update them if you want using '${CLI_NAME} provider update-offer' command`,
+        )}. You can update them if you want using '${CLI_NAME} provider offer-update' command`,
     );
   }
 


### PR DESCRIPTION
```
% fluence provider update-offer
 ›   Warning: provider update-offer is not a fluence command.
Did you mean provider update? [y/n]:
```