### PR TITLE
feat(vm): add vmConfig to computePeer.nox

### DIFF
--- a/cli/docs/configs/provider.md
+++ b/cli/docs/configs/provider.md
@@ -197,6 +197,7 @@ Configuration to pass to the nox compute peer. Config.toml files are generated f
 | `systemCpuCount`         | integer                   | No       | Number of CPU cores to allocate for the Nox itself. Default: 1                                                    |
 | `systemServices`         | [object](#systemservices) | No       | System services to run by default. aquaIpfs and decider are enabled by default                                    |
 | `tcpPort`                | integer                   | No       | Both host and container TCP port to use. Default: for each nox a unique port is assigned starting from 7771       |
+| `vmConfig`               | [object](#vmconfig)       | No       | VM Configuration                                                                                                  |
 | `websocketPort`          | integer                   | No       | Both host and container WebSocket port to use. Default: for each nox a unique port is assigned starting from 9991 |
 
 ##### ccp
@@ -326,6 +327,42 @@ Decider service configuration
 | `walletKey`           | string  | No       | Wallet key (deprecated)           |
 | `workerIpfsMultiaddr` | string  | No       | Multiaddress of worker IPFS node  |
 
+##### vmConfig
+
+VM Configuration
+
+###### Properties
+
+| Property     | Type               | Required | Description                                |
+|--------------|--------------------|----------|--------------------------------------------|
+| `network`    | [object](#network) | **Yes**  | VM Network Configuration                   |
+| `allowGpu`   | boolean            | No       | Whether to add info about GPUs to VM's XML |
+| `libvirtUri` | string             | No       | QEMU Socket                                |
+
+###### network
+
+VM Network Configuration
+
+**Properties**
+
+| Property     | Type                 | Required | Description                                                      |
+|--------------|----------------------|----------|------------------------------------------------------------------|
+| `publicIp`   | string               | **Yes**  | Public IP address to assign the VM. Must be publicly accessible. |
+| `bridgeName` | string               | No       | Name of the network bridge device                                |
+| `portRange`  | [object](#portrange) | No       | iptables-mapped port range from Host to VM                       |
+| `vmIp`       | string               | No       | Internal IP address to assign the VM                             |
+
+**portRange**
+
+iptables-mapped port range from Host to VM
+
+**Properties**
+
+| Property | Type    | Required | Description                                             |
+|----------|---------|----------|---------------------------------------------------------|
+| `end`    | integer | No       | End of the iptables-mapped port range from Host to VM   |
+| `start`  | integer | No       | Start of the iptables-mapped port range from Host to VM |
+
 ## nox
 
 Configuration to pass to the nox compute peer. Config.toml files are generated from this config
@@ -349,6 +386,7 @@ Configuration to pass to the nox compute peer. Config.toml files are generated f
 | `systemCpuCount`         | integer                   | No       | Number of CPU cores to allocate for the Nox itself. Default: 1                                                    |
 | `systemServices`         | [object](#systemservices) | No       | System services to run by default. aquaIpfs and decider are enabled by default                                    |
 | `tcpPort`                | integer                   | No       | Both host and container TCP port to use. Default: for each nox a unique port is assigned starting from 7771       |
+| `vmConfig`               | [object](#vmconfig)       | No       | VM Configuration                                                                                                  |
 | `websocketPort`          | integer                   | No       | Both host and container WebSocket port to use. Default: for each nox a unique port is assigned starting from 9991 |
 
 ### ccp
@@ -477,6 +515,42 @@ Decider service configuration
 | `startBlock`          | string  | No       | Start block (deprecated)          |
 | `walletKey`           | string  | No       | Wallet key (deprecated)           |
 | `workerIpfsMultiaddr` | string  | No       | Multiaddress of worker IPFS node  |
+
+### vmConfig
+
+VM Configuration
+
+#### Properties
+
+| Property     | Type               | Required | Description                                |
+|--------------|--------------------|----------|--------------------------------------------|
+| `network`    | [object](#network) | **Yes**  | VM Network Configuration                   |
+| `allowGpu`   | boolean            | No       | Whether to add info about GPUs to VM's XML |
+| `libvirtUri` | string             | No       | QEMU Socket                                |
+
+#### network
+
+VM Network Configuration
+
+##### Properties
+
+| Property     | Type                 | Required | Description                                                      |
+|--------------|----------------------|----------|------------------------------------------------------------------|
+| `publicIp`   | string               | **Yes**  | Public IP address to assign the VM. Must be publicly accessible. |
+| `bridgeName` | string               | No       | Name of the network bridge device                                |
+| `portRange`  | [object](#portrange) | No       | iptables-mapped port range from Host to VM                       |
+| `vmIp`       | string               | No       | Internal IP address to assign the VM                             |
+
+##### portRange
+
+iptables-mapped port range from Host to VM
+
+###### Properties
+
+| Property | Type    | Required | Description                                             |
+|----------|---------|----------|---------------------------------------------------------|
+| `end`    | integer | No       | End of the iptables-mapped port range from Host to VM   |
+| `start`  | integer | No       | Start of the iptables-mapped port range from Host to VM |
 
 ## offers
 

--- a/cli/docs/configs/provider.md
+++ b/cli/docs/configs/provider.md
@@ -197,7 +197,7 @@ Configuration to pass to the nox compute peer. Config.toml files are generated f
 | `systemCpuCount`         | integer                   | No       | Number of CPU cores to allocate for the Nox itself. Default: 1                                                    |
 | `systemServices`         | [object](#systemservices) | No       | System services to run by default. aquaIpfs and decider are enabled by default                                    |
 | `tcpPort`                | integer                   | No       | Both host and container TCP port to use. Default: for each nox a unique port is assigned starting from 7771       |
-| `vmConfig`               | [object](#vmconfig)       | No       | VM Configuration                                                                                                  |
+| `vm`                     | [object](#vm)             | No       | VM Configuration                                                                                                  |
 | `websocketPort`          | integer                   | No       | Both host and container WebSocket port to use. Default: for each nox a unique port is assigned starting from 9991 |
 
 ##### ccp
@@ -327,7 +327,7 @@ Decider service configuration
 | `walletKey`           | string  | No       | Wallet key (deprecated)           |
 | `workerIpfsMultiaddr` | string  | No       | Multiaddress of worker IPFS node  |
 
-##### vmConfig
+##### vm
 
 VM Configuration
 
@@ -386,7 +386,7 @@ Configuration to pass to the nox compute peer. Config.toml files are generated f
 | `systemCpuCount`         | integer                   | No       | Number of CPU cores to allocate for the Nox itself. Default: 1                                                    |
 | `systemServices`         | [object](#systemservices) | No       | System services to run by default. aquaIpfs and decider are enabled by default                                    |
 | `tcpPort`                | integer                   | No       | Both host and container TCP port to use. Default: for each nox a unique port is assigned starting from 7771       |
-| `vmConfig`               | [object](#vmconfig)       | No       | VM Configuration                                                                                                  |
+| `vm`                     | [object](#vm)             | No       | VM Configuration                                                                                                  |
 | `websocketPort`          | integer                   | No       | Both host and container WebSocket port to use. Default: for each nox a unique port is assigned starting from 9991 |
 
 ### ccp
@@ -516,7 +516,7 @@ Decider service configuration
 | `walletKey`           | string  | No       | Wallet key (deprecated)           |
 | `workerIpfsMultiaddr` | string  | No       | Multiaddress of worker IPFS node  |
 
-### vmConfig
+### vm
 
 VM Configuration
 

--- a/cli/src/lib/configs/project/provider.ts
+++ b/cli/src/lib/configs/project/provider.ts
@@ -418,7 +418,7 @@ type NoxConfigYAMLV1 = Omit<NoxConfigYAMLV0, "chainConfig"> & {
     tokioDetailedMetricsEnabled?: boolean;
   };
   bootstrapNodes?: Array<string>;
-  vmConfig?: {
+  vm?: {
     libvirtUri?: string;
     allowGpu?: boolean;
     network: {
@@ -737,7 +737,7 @@ const noxConfigYAMLSchemaV1 = {
       type: "string",
       description: `Raw TOML config string to parse and merge with the rest of the config. Has the highest priority`,
     },
-    vmConfig: {
+    vm: {
       type: "object",
       description: "VM Configuration",
       additionalProperties: false,

--- a/cli/src/lib/configs/project/provider.ts
+++ b/cli/src/lib/configs/project/provider.ts
@@ -426,11 +426,11 @@ type NoxConfigYAMLV1 = Omit<NoxConfigYAMLV0, "chainConfig"> & {
       publicIp: string;
       vmIp?: string;
       portRange?: {
-        start?: number,
-        end?: number
-      }
-    }
-  }
+        start?: number;
+        end?: number;
+      };
+    };
+  };
 };
 
 const DEFAULT_TIMER_RESOLUTION = "1 minute";
@@ -792,12 +792,12 @@ const noxConfigYAMLSchemaV1 = {
                   nullable: true,
                   type: "integer",
                   description: `End of the iptables-mapped port range from Host to VM`,
-                }
-              }
-            }
-          }
-        }
-      }
+                },
+              },
+            },
+          },
+        },
+      },
     },
   },
   required: [],

--- a/cli/src/lib/configs/project/provider.ts
+++ b/cli/src/lib/configs/project/provider.ts
@@ -418,6 +418,19 @@ type NoxConfigYAMLV1 = Omit<NoxConfigYAMLV0, "chainConfig"> & {
     tokioDetailedMetricsEnabled?: boolean;
   };
   bootstrapNodes?: Array<string>;
+  vmConfig?: {
+    libvirtUri?: string;
+    allowGpu?: boolean;
+    network: {
+      bridgeName?: string;
+      publicIp: string;
+      vmIp?: string;
+      portRange?: {
+        start?: number,
+        end?: number
+      }
+    }
+  }
 };
 
 const DEFAULT_TIMER_RESOLUTION = "1 minute";
@@ -723,6 +736,68 @@ const noxConfigYAMLSchemaV1 = {
       nullable: true,
       type: "string",
       description: `Raw TOML config string to parse and merge with the rest of the config. Has the highest priority`,
+    },
+    vmConfig: {
+      type: "object",
+      description: "VM Configuration",
+      additionalProperties: false,
+      nullable: true,
+      required: ["network"],
+      properties: {
+        libvirtUri: {
+          nullable: true,
+          type: "string",
+          description: `QEMU Socket`,
+        },
+        allowGpu: {
+          nullable: true,
+          type: "boolean",
+          description: `Whether to add info about GPUs to VM's XML`,
+        },
+        network: {
+          type: "object",
+          description: "VM Network Configuration",
+          additionalProperties: false,
+          nullable: false,
+          required: ["publicIp"],
+          properties: {
+            bridgeName: {
+              nullable: true,
+              type: "string",
+              description: `Name of the network bridge device`,
+            },
+            publicIp: {
+              nullable: false,
+              type: "string",
+              description: `Public IP address to assign the VM. Must be publicly accessible.`,
+            },
+            vmIp: {
+              nullable: true,
+              type: "string",
+              description: `Internal IP address to assign the VM`,
+            },
+            portRange: {
+              type: "object",
+              description: "iptables-mapped port range from Host to VM",
+              additionalProperties: false,
+              nullable: true,
+              required: [],
+              properties: {
+                start: {
+                  nullable: true,
+                  type: "integer",
+                  description: `Start of the iptables-mapped port range from Host to VM`,
+                },
+                end: {
+                  nullable: true,
+                  type: "integer",
+                  description: `End of the iptables-mapped port range from Host to VM`,
+                }
+              }
+            }
+          }
+        }
+      }
     },
   },
   required: [],


### PR DESCRIPTION
### Minimal

Here's how minimal config will look like in `provider.yml`

```yaml
computePeers:
  nox-2:
    computeUnits: 60
    nox:
      vm:
        network:
          publicIp: 1.1.1.1
```

Here's how minimal config will look like in `Config.toml`

```toml
[vm.network]
public_ip = "1.1.1.1"
```

### Full

Here's how full config will look like in `provider.yml`

```yaml
computePeers:
  nox-2:
    computeUnits: 60
    nox:
      vm:
        libvirtUri: qemu:///system
        allowGpu: false
        network:
          bridgeName: virbr0
          publicIp: 1.1.1.1
          vmIp: "192.168.122.112"
```

Here's how full config will look like in `Config.toml`

```toml
[vm]
libvirt_uri = "qemu:///system"
allow_gpu = false

  [vm_config.network]
  bridge_name = "virbr0"
  public_ip = "1.1.1.1"
  vm_ip = "192.168.122.112"
```