### PR TITLE
fix: replace wasm32-wasi target with wasm32-wasip1

### DIFF
--- a/packages/cli/package/src/lib/const.ts
+++ b/packages/cli/package/src/lib/const.ts
@@ -48,7 +48,7 @@ export const PT_SYMBOL = "USDC";
 
 export const MAX_TOKEN_AMOUNT_KEYWORD = "max";
 
-export const RUST_WASM32_WASI_TARGET = "wasm32-wasi";
+export const RUST_WASM32_WASI_TARGET = "wasm32-wasip1";
 
 export const DEFAULT_MARINE_BUILD_ARGS = `--release`;
 

--- a/packages/cli/package/src/lib/helpers/downloadFile.ts
+++ b/packages/cli/package/src/lib/helpers/downloadFile.ts
@@ -167,7 +167,7 @@ export function getModuleWasmPath(moduleConfig: {
   const fileName = `${moduleConfig.name}.${WASM_EXT}`;
   const configDirName = moduleConfig.$getDirPath();
   return moduleConfig.type === MODULE_TYPE_RUST
-    ? resolve(projectRootDir, "target", "wasm32-wasi", "release", fileName)
+    ? resolve(projectRootDir, "target", "wasm32-wasip1", "release", fileName)
     : resolve(configDirName, fileName);
 }
 

--- a/packages/cli/package/src/lib/rust.ts
+++ b/packages/cli/package/src/lib/rust.ts
@@ -183,7 +183,7 @@ targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",
   "x86_64-apple-darwin",
-  "wasm32-wasi",
+  "wasm32-wasip1",
   "wasm32-unknown-unknown",
 ]`,
     FS_OPTIONS,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2024-06-10"
-targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasip1"]


### PR DESCRIPTION
dependency: https://github.com/fluencelabs/marine/pull/439
needs to wait until the above pr been released to set correct version in the dependencies of `/packages/cli/package/package.json`

refer to the renaming:
https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip1.html
currently in beta and nightly, the wasm32-wasi target has been removed.

Original issue:
```bash
fluence init hello-fluence
```
Just doesn't compile. The rust version in cli is nightly 2024.6.10, which already removed `wasm32-wasi` from the target.
Also notice that the rust version in `marine` is different from `cli` 